### PR TITLE
skip auto-approve job, instead of step

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -3,9 +3,9 @@ on: pull_request
 
 jobs:
   build:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: hmarr/auto-approve-action@v2.0.0
-      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,7 +2,7 @@ name: Auto approve
 on: pull_request
 
 jobs:
-  build:
+  approve:
     if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Very minor thing I noticed when setting up a version of this.

Putting the conditional on the job rather than the step means that the check will show in the GitHub UI as "skipped" where appropriate, rather than "success".

Also updates the job name to be more appropriate (`approve` instead of `build`).