### PR TITLE
Update AWS lambda timeout

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -33,7 +33,7 @@ provider:
   region: us-east-1
   runtime: nodejs12.x
   memorySize: 512
-  timeout: 30
+  timeout: 29
   iamRoleStatements:
     - Effect: Allow
       Action:


### PR DESCRIPTION
Another very minor thing I noticed when deploying our own version of this:
```
 Serverless Warning --------------------------------------
 
 Function timeout setting (30) is greater than maximum allowed timeout for HTTP API endpoint (29s). This may introduce situation where endpoint times out for succesful lambda invocation.
```

This updates the setting to match the maximum.