### PR TITLE
use client ID from environment

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -133,7 +133,10 @@ function createServerlessApp() {
                     })
                 }
             }
-            return res.render('setup-github', { token: result })
+            return res.render('setup-github', {
+                token: result,
+                clientId: process.env.GITHUB_CLIENT_ID,
+            })
         }),
     )
     app.get(

--- a/src/views/setup-github.mustache
+++ b/src/views/setup-github.mustache
@@ -30,7 +30,7 @@
             {{/token}}
             {{^token}}
                 <p>Setup bundlewatch on your Pull Requests by Authorizing bundlewatch on Github</p>
-                <a class="btn" data-title='Authorize on Github' href="https://github.com/login/oauth/authorize?scope=repo%3Astatus&client_id=04fcf325dd26ca2a159f"></a>
+                <a class="btn" data-title='Authorize on Github' href="https://github.com/login/oauth/authorize?scope=repo%3Astatus&client_id={{clientId}}"></a>
             {{/token}}
         </div>
         <p style="padding-top: 24px; text-align: right;">


### PR DESCRIPTION
Noticed that my local instance was not linking me to the correct GitHub authorize URL, due to a hardcoded client ID.

This uses the value configured in the environment instead.