### PR TITLE
fix: remove awscli from install-deployment-deps.sh

### DIFF
--- a/infrastructure/deployment/install-deployment-deps.sh
+++ b/infrastructure/deployment/install-deployment-deps.sh
@@ -4,7 +4,3 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "$DIR/../shell-helpers.sh"
 
 run "sudo npm install -g serverless"
-run "sudo apt-get update"
-run "sudo apt-get install python-setuptools python-dev build-essential"
-run "sudo easy_install pip"
-run "sudo pip install awscli"


### PR DESCRIPTION
Currently, on CircleCI we have the following error on deploy:

```bash
>>> sudo easy_install pip
Searching for pip
Reading https://pypi.python.org/simple/pip/
Couldn't find index page for 'pip' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading https://pypi.python.org/simple/
No local packages or working download links found for pip
error: Could not find suitable distribution for Requirement.parse('pip')
>>> Command Failed. Exiting Now
Makefile:59: recipe for target 'install-deployment-deps' failed
make: *** [install-deployment-deps] Error 1
```

It seems like we don't need to install `awscli` after all?