### PR TITLE
Remove deprecated `lambdaHashingVersion`

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -36,7 +36,6 @@ provider:
     name: aws
     region: us-east-1
     runtime: nodejs20.x
-    lambdaHashingVersion: '20201221'
     memorySize: 512
     timeout: 29
     iam:


### PR DESCRIPTION
```
serverless doctor

Running "serverless" from node_modules
1 deprecation triggered in the last command:

Setting "20201221" for "provider.lambdaHashingVersion" is no longer effective as new hashing algorithm is now used by default. You can safely remove this property from your configuration.
More info: https://serverless.com/framework/docs/deprecations/#LAMBDA_HASHING_VERSION_PROPERTY
```